### PR TITLE
Thumbnail lookup should return null on failure

### DIFF
--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -259,11 +259,11 @@ export const getThumbnailForGallery = async(c, GalleryTableName) => {
     ).bind(GalleryTableName).run();
     
     if (results == null || results.length == 0)
-      return "/meta-card.png";
+      return null;
 
     return getImageWithTransforms(c, results[0].CoverImage, "gallery-thumb");
   } catch (error) {
     console.error("Error getting thumbnail:", error.message);
-    return false;
+    return null;
   }
 };


### PR DESCRIPTION
And not explicitly return the meta-card. This was originally done because I was going to have dynamic meta tags but while I was doing said process, I realized it would not work on my setup as I disabled hotlinking temporarily.